### PR TITLE
Make everything static

### DIFF
--- a/CallSiteStats.php
+++ b/CallSiteStats.php
@@ -6,8 +6,8 @@
  ************************************************************************/
 trait CallSiteStats {
    protected static $callSiteStatsEnabled = true;
-   protected $_callSiteStats = [];
-   public $_callSiteSeconds = 0;
+   protected static $_callSiteStats = [];
+   public static $_callSiteSeconds = 0;
 
    /**
     * Enable or disable call site stats collection.
@@ -35,19 +35,19 @@ trait CallSiteStats {
     *
     * If CallSiteStats collection has been disabled, this returns null.
     */
-   public function getCallSiteStats() {
+   public static function getCallSiteStats() {
       if (!self::$callSiteStatsEnabled) {
          return null;
       }
       $time = microtime(true);
       $outStats = [];
-      foreach($this->_callSiteStats as $site => $stats) {
+      foreach(self::$_callSiteStats as $site => $stats) {
          foreach($stats as $statLine) {
             $outStats[] = "{$site} {$statLine}";
          }
       }
       $results = implode("\n", $outStats);
-      $this->_callSiteSeconds += microtime(true) - $time;
+      self::$_callSiteSeconds += microtime(true) - $time;
       return $results;
    }
 
@@ -55,24 +55,24 @@ trait CallSiteStats {
     * Records the passed arguments for the function 
     * call-site that called into this class.
     */
-   protected function recordCallSite() {
+   protected static function recordCallSite() {
       if (!self::$callSiteStatsEnabled) {
          return null;
       }
 
       $time = microtime(true);
-      $callSite = $this->getCallSite();
+      $callSite = self::getCallSite();
       if (!$callSite) {
          return;
       }
 
       $data = implode(' ', func_get_args());
-      if (isset($this->_callSiteStats[$callSite])) {
-         $this->_callSiteStats[$callSite][] = $data;
+      if (isset(self::$_callSiteStats[$callSite])) {
+         self::$_callSiteStats[$callSite][] = $data;
       } else {
-         $this->_callSiteStats[$callSite] = [$data];
+         self::$_callSiteStats[$callSite] = [$data];
       }
-      $this->_callSiteSeconds += microtime(true) - $time;
+      self::$_callSiteSeconds += microtime(true) - $time;
    }
 
    /**
@@ -81,7 +81,7 @@ trait CallSiteStats {
     *
     * Returns null if one can't be found.
     */
-   protected function getCallSite() {
+   protected static function getCallSite() {
       $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 7);
       $length = count($trace);
 
@@ -89,7 +89,7 @@ trait CallSiteStats {
          $frame = $trace[$i];
          if (isset($frame['file']) &&
           $frame['file'] != __FILE__ &&
-          $this->isExternalCallSite($frame['file'])) {
+          self::isExternalCallSite($frame['file'])) {
             return $frame['file'] . ":" . $frame['line'];
          }
       }

--- a/Tests/CallSiteStatsTest.php
+++ b/Tests/CallSiteStatsTest.php
@@ -13,7 +13,7 @@ class CallSiteStatsTest extends PHPUnit_Framework_TestCase {
    public function testRecordCallSite() {
       $m = new Mock();
       $m->something(100);
-      $stats = $m->getCallSiteStats();
+      $stats = Mock::getCallSiteStats();
       $this->assertStringEndsWith('/CallSiteStatsTest.php:15 100', $stats);
 
       $m->something('blah');

--- a/Tests/Mock.php
+++ b/Tests/Mock.php
@@ -3,15 +3,15 @@
 class Mock {
    use CallSiteStats;
 
-   public function getCallSitePublic() {
-      return $this->getCallSite();
+   public static function getCallSitePublic() {
+      return self::getCallSite();
    }
 
    public function something() {
       call_user_func_array([$this, 'recordCallSite'], func_get_args());
    }
 
-   protected function isExternalCallSite($file) {
+   protected static function isExternalCallSite($file) {
       return $file != __FILE__;
    }
 }


### PR DESCRIPTION
It makes more sense for these functions which are supposed to record
values for aggregation be static instead of instance. This is
particularly true for stats collection. It would be annoying to have to
collect and aggregate stats across many instances of a class, collecting
the results statically makes more sense.

Though, PHP being the odd language it is, still allows you to call
static methods in an instancey way: `$this->someStaticMethod()` is
valid.
